### PR TITLE
Add Playwright visual regression testing

### DIFF
--- a/.github/workflows/jekyll.yml
+++ b/.github/workflows/jekyll.yml
@@ -11,6 +11,10 @@ on:
   push:
     branches: ["master"]
 
+  # Run visual tests on pull requests to master
+  pull_request:
+    branches: ["master"]
+
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 
@@ -27,8 +31,65 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
+  # Visual regression tests job
+  visual-tests:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          lfs: true
+
+      - name: Generate Tags
+        shell: pwsh
+        run: ./.tag_generator.ps1
+
+      - name: Setup Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '3.3'
+          bundler-cache: true
+          cache-version: 0
+
+      - name: Bundle Install
+        run: bundle install
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+
+      - name: Install npm dependencies
+        run: npm ci
+
+      - name: Install Playwright Chromium
+        run: npx playwright install chromium --with-deps
+
+      - name: Run visual regression tests
+        run: npm run test:visual
+
+      - name: Upload Playwright report
+        uses: actions/upload-artifact@v4
+        if: failure()
+        with:
+          name: playwright-report
+          path: playwright-report/
+          retention-days: 7
+
+      - name: Upload test results
+        uses: actions/upload-artifact@v4
+        if: failure()
+        with:
+          name: test-results
+          path: test-results/
+          retention-days: 7
+
   # Build job
   build:
+    needs: visual-tests
+    # Only run build/deploy on push to master, not on PRs
+    if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/.github/workflows/update-visual-baselines.yml
+++ b/.github/workflows/update-visual-baselines.yml
@@ -1,0 +1,70 @@
+# Workflow to generate/update visual regression baselines on Linux
+# Run this manually when you need to establish or update baseline screenshots
+
+name: Update Visual Baselines
+
+on:
+  workflow_dispatch:
+    inputs:
+      commit_message:
+        description: 'Commit message for baseline update'
+        required: false
+        default: 'Update visual regression baselines'
+
+permissions:
+  contents: write
+
+jobs:
+  update-baselines:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          lfs: true
+          # Need to use a token with write access to push commits
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Generate Tags
+        shell: pwsh
+        run: ./.tag_generator.ps1
+
+      - name: Setup Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '3.3'
+          bundler-cache: true
+          cache-version: 0
+
+      - name: Bundle Install
+        run: bundle install
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+
+      - name: Install npm dependencies
+        run: npm ci
+
+      - name: Install Playwright Chromium
+        run: npx playwright install chromium --with-deps
+
+      - name: Generate baseline screenshots
+        run: npm run test:visual:update
+
+      - name: Configure Git
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+      - name: Commit and push baselines
+        run: |
+          git add e2e/__snapshots__/
+          if git diff --staged --quiet; then
+            echo "No changes to baselines"
+          else
+            git commit -m "${{ github.event.inputs.commit_message }}"
+            git push
+          fi

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,11 @@ _site
 .jekyll-cache
 .DS_Store
 tag
+
+# Node.js
+node_modules/
+
+# Playwright
+playwright-report/
+test-results/
+playwright/.cache/

--- a/e2e/__snapshots__/visual-regression.spec.ts/404-Desktop.png
+++ b/e2e/__snapshots__/visual-regression.spec.ts/404-Desktop.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:fc49de7f679f4ab00050288fe307b44cbcfd520297558ce6715e92a3e668e9f7
+size 227082

--- a/e2e/__snapshots__/visual-regression.spec.ts/404-Mobile.png
+++ b/e2e/__snapshots__/visual-regression.spec.ts/404-Mobile.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ccc698de7d1d0c054acd921aca76a25f2875f7ecc100d7e34cd31e54f611ab07
+size 127151

--- a/e2e/__snapshots__/visual-regression.spec.ts/404-Tablet.png
+++ b/e2e/__snapshots__/visual-regression.spec.ts/404-Tablet.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1eb6653629a86143eddcbb8990c51d54c5f24d4160ca302f6eaf02f20733c64a
+size 156115

--- a/e2e/__snapshots__/visual-regression.spec.ts/about-Desktop.png
+++ b/e2e/__snapshots__/visual-regression.spec.ts/about-Desktop.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7594f194c2a0c20f8da0698a4697d7ffbc0686b136d768bd011d048445af3fd0
+size 2930467

--- a/e2e/__snapshots__/visual-regression.spec.ts/about-Mobile.png
+++ b/e2e/__snapshots__/visual-regression.spec.ts/about-Mobile.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:161c4529b8f01290c6834f09889357334567206f1ec4bc5890cc2d8c02caacdb
+size 1533220

--- a/e2e/__snapshots__/visual-regression.spec.ts/about-Tablet.png
+++ b/e2e/__snapshots__/visual-regression.spec.ts/about-Tablet.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c83fba1d7e7f4c0f1f3e8ede91a25186922c44d7d8b4f3b3005d1462383a2f52
+size 1764117

--- a/e2e/__snapshots__/visual-regression.spec.ts/archive-Desktop.png
+++ b/e2e/__snapshots__/visual-regression.spec.ts/archive-Desktop.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1e6eb296f7e94afaa0fb3f5b7c9d1e751237207760cf34c7a8b5d65076d174e4
+size 593937

--- a/e2e/__snapshots__/visual-regression.spec.ts/archive-Mobile.png
+++ b/e2e/__snapshots__/visual-regression.spec.ts/archive-Mobile.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:10329048478a6dd26d168d08ebd0eb69416bae4d900761b310f648e29a7cfe11
+size 473638

--- a/e2e/__snapshots__/visual-regression.spec.ts/archive-Tablet.png
+++ b/e2e/__snapshots__/visual-regression.spec.ts/archive-Tablet.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:be8e3ef59d599b18a62e5d56acf5bd9a834fc7d5869ddcfd537928bdff57bc25
+size 481226

--- a/e2e/__snapshots__/visual-regression.spec.ts/homepage-Desktop.png
+++ b/e2e/__snapshots__/visual-regression.spec.ts/homepage-Desktop.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:aa2417ef70836fb491d2ff15f839551350216fb92323ac6e799a98076fdd9a70
+size 732752

--- a/e2e/__snapshots__/visual-regression.spec.ts/homepage-Mobile.png
+++ b/e2e/__snapshots__/visual-regression.spec.ts/homepage-Mobile.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:21099cd896393f6131e72e15b7cc5419ef1c3a1acff1d7d4c1d8a3d1fd86d955
+size 564445

--- a/e2e/__snapshots__/visual-regression.spec.ts/homepage-Tablet.png
+++ b/e2e/__snapshots__/visual-regression.spec.ts/homepage-Tablet.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5025d97f6d8cd352556128e8eab03d300cb4423e30735af1aa8372a85e444c4e
+size 576971

--- a/e2e/__snapshots__/visual-regression.spec.ts/linkfarm-Desktop.png
+++ b/e2e/__snapshots__/visual-regression.spec.ts/linkfarm-Desktop.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:dd753fc284478848ba9d6e89202b5b7f4ad76a4d2e31bda042e2a1a3760a6046
+size 4881105

--- a/e2e/__snapshots__/visual-regression.spec.ts/linkfarm-Mobile.png
+++ b/e2e/__snapshots__/visual-regression.spec.ts/linkfarm-Mobile.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1a25958d9d142c862ab97dd6237a3a1ccf8f032937f40040fae5ab2a899c6d2a
+size 4381677

--- a/e2e/__snapshots__/visual-regression.spec.ts/linkfarm-Tablet.png
+++ b/e2e/__snapshots__/visual-regression.spec.ts/linkfarm-Tablet.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a9192786fa99df89d585011cce893ce4ad72fa1e072b5ad8d3894da36f528c69
+size 3739244

--- a/e2e/__snapshots__/visual-regression.spec.ts/post-standard-Desktop.png
+++ b/e2e/__snapshots__/visual-regression.spec.ts/post-standard-Desktop.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:110aed0073acaf9e1e83506daeb3711ca11c144cde645e0e92c6d2da0daeb993
+size 469041

--- a/e2e/__snapshots__/visual-regression.spec.ts/post-standard-Mobile.png
+++ b/e2e/__snapshots__/visual-regression.spec.ts/post-standard-Mobile.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a139382b4efc5a04c573d0006a73fe402bf1b609ba61cbfc269097d3bcfb5432
+size 438943

--- a/e2e/__snapshots__/visual-regression.spec.ts/post-standard-Tablet.png
+++ b/e2e/__snapshots__/visual-regression.spec.ts/post-standard-Tablet.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e420316eed4b58d5d1a4a03dfa9fe6dd35ec46b4d5dc797d1aea307f87590e0f
+size 418310

--- a/e2e/__snapshots__/visual-regression.spec.ts/post-with-code-Desktop.png
+++ b/e2e/__snapshots__/visual-regression.spec.ts/post-with-code-Desktop.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ad3036b2efb41a9d59638aa077201553c58574fb6d7bb79ac96448d2d2700b10
+size 2781034

--- a/e2e/__snapshots__/visual-regression.spec.ts/post-with-code-Mobile.png
+++ b/e2e/__snapshots__/visual-regression.spec.ts/post-with-code-Mobile.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c12b6f6ef9d256697afc24e2af8fefdc8ae6b558dec63a8470dca2b468a33748
+size 2022386

--- a/e2e/__snapshots__/visual-regression.spec.ts/post-with-code-Tablet.png
+++ b/e2e/__snapshots__/visual-regression.spec.ts/post-with-code-Tablet.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8498e9c00bd1445935d70fec9a1fdb0cfbea949fc59fc48a6da77d61037438c3
+size 2028563

--- a/e2e/__snapshots__/visual-regression.spec.ts/tag-ai-Desktop.png
+++ b/e2e/__snapshots__/visual-regression.spec.ts/tag-ai-Desktop.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:fc49de7f679f4ab00050288fe307b44cbcfd520297558ce6715e92a3e668e9f7
+size 227082

--- a/e2e/__snapshots__/visual-regression.spec.ts/tag-ai-Mobile.png
+++ b/e2e/__snapshots__/visual-regression.spec.ts/tag-ai-Mobile.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ccc698de7d1d0c054acd921aca76a25f2875f7ecc100d7e34cd31e54f611ab07
+size 127151

--- a/e2e/__snapshots__/visual-regression.spec.ts/tag-ai-Tablet.png
+++ b/e2e/__snapshots__/visual-regression.spec.ts/tag-ai-Tablet.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1eb6653629a86143eddcbb8990c51d54c5f24d4160ca302f6eaf02f20733c64a
+size 156115

--- a/e2e/__snapshots__/visual-regression.spec.ts/tags-index-Desktop.png
+++ b/e2e/__snapshots__/visual-regression.spec.ts/tags-index-Desktop.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:cd4f4c5c698bfff70a75eedbdb63a455a013e6cee7bf426277d703e4ea082576
+size 2165536

--- a/e2e/__snapshots__/visual-regression.spec.ts/tags-index-Mobile.png
+++ b/e2e/__snapshots__/visual-regression.spec.ts/tags-index-Mobile.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a05ad5a6ab58d4f4926f880f7e40bf83bd106241bedff6d54bc6871b5d0d4340
+size 1324069

--- a/e2e/__snapshots__/visual-regression.spec.ts/tags-index-Tablet.png
+++ b/e2e/__snapshots__/visual-regression.spec.ts/tags-index-Tablet.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:159cca1782bc32113dacef3431205f8d082eceadeee6fa4ccc77ddf15e742448
+size 1396018

--- a/e2e/visual-regression.spec.ts
+++ b/e2e/visual-regression.spec.ts
@@ -1,0 +1,108 @@
+import { test, expect, Page } from '@playwright/test';
+
+/**
+ * Visual regression tests for the Jekyll blog.
+ * These tests capture screenshots of all major page types to ensure
+ * visual consistency during HTML/CSS refactoring.
+ */
+
+/**
+ * Prepare the page for consistent screenshots:
+ * - Wait for fonts to load
+ * - Wait for network to be idle
+ * - Disable all animations and transitions
+ */
+async function preparePageForScreenshot(page: Page): Promise<void> {
+  // Wait for fonts to load
+  await page.evaluate(() => document.fonts.ready);
+
+  // Wait for network to settle
+  await page.waitForLoadState('networkidle');
+
+  // Disable animations and transitions for consistent screenshots
+  await page.addStyleTag({
+    content: `
+      *, *::before, *::after {
+        animation-duration: 0s !important;
+        animation-delay: 0s !important;
+        transition-duration: 0s !important;
+        transition-delay: 0s !important;
+      }
+    `,
+  });
+
+  // Small delay to ensure styles are applied
+  await page.waitForTimeout(100);
+}
+
+/**
+ * Take a full-page screenshot with a descriptive name.
+ */
+async function takeFullPageScreenshot(page: Page, name: string): Promise<void> {
+  await preparePageForScreenshot(page);
+  await expect(page).toHaveScreenshot(`${name}.png`, {
+    fullPage: true,
+  });
+}
+
+test.describe('Homepage', () => {
+  test('visual appearance', async ({ page }) => {
+    await page.goto('/');
+    await takeFullPageScreenshot(page, 'homepage');
+  });
+});
+
+test.describe('Blog Post', () => {
+  test('post with code blocks', async ({ page }) => {
+    // Test a post that contains code blocks to verify syntax highlighting
+    await page.goto('/2024/04/a-no-nonense-guide-to-setting-up-python-environments/');
+    await takeFullPageScreenshot(page, 'post-with-code');
+  });
+
+  test('standard post', async ({ page }) => {
+    // Test a standard text-heavy post
+    await page.goto('/2023/03/the-return/');
+    await takeFullPageScreenshot(page, 'post-standard');
+  });
+});
+
+test.describe('Archive', () => {
+  test('visual appearance', async ({ page }) => {
+    await page.goto('/archive/');
+    await takeFullPageScreenshot(page, 'archive');
+  });
+});
+
+test.describe('Tags', () => {
+  test('tags index page', async ({ page }) => {
+    await page.goto('/tags/');
+    await takeFullPageScreenshot(page, 'tags-index');
+  });
+
+  test('individual tag page', async ({ page }) => {
+    // Test a tag page with multiple posts
+    await page.goto('/tag/ai/');
+    await takeFullPageScreenshot(page, 'tag-ai');
+  });
+});
+
+test.describe('About', () => {
+  test('visual appearance', async ({ page }) => {
+    await page.goto('/about/');
+    await takeFullPageScreenshot(page, 'about');
+  });
+});
+
+test.describe('Linkfarm', () => {
+  test('visual appearance', async ({ page }) => {
+    await page.goto('/linkfarm/');
+    await takeFullPageScreenshot(page, 'linkfarm');
+  });
+});
+
+test.describe('404 Page', () => {
+  test('visual appearance', async ({ page }) => {
+    await page.goto('/404.html');
+    await takeFullPageScreenshot(page, '404');
+  });
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,111 @@
+{
+  "name": "ryanspletzer-github-io",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "ryanspletzer-github-io",
+      "version": "1.0.0",
+      "devDependencies": {
+        "@playwright/test": "^1.50.0",
+        "@types/node": "^22.0.0",
+        "typescript": "^5.7.0"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.58.0",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.58.0.tgz",
+      "integrity": "sha512-fWza+Lpbj6SkQKCrU6si4iu+fD2dD3gxNHFhUPxsfXBPhnv3rRSQVd0NtBUT9Z/RhF/boCBcuUaMUSTRTopjZg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.58.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "22.19.7",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.7.tgz",
+      "integrity": "sha512-MciR4AKGHWl7xwxkBa6xUGxQJ4VBOmPTF7sL+iGzuahOFaO0jHCsuEfS80pan1ef4gWId1oWOweIhrDEYLuaOw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.58.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.58.0.tgz",
+      "integrity": "sha512-2SVA0sbPktiIY/MCOPX8e86ehA/e+tDNq+e5Y8qjKYti2Z/JG7xnronT/TXTIkKbYGWlCbuucZ6dziEgkoEjQQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.58.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.58.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.58.0.tgz",
+      "integrity": "sha512-aaoB1RWrdNi3//rOeKuMiS65UCcgOVljU46At6eFcOFPFHWtd2weHRRow6z/n+Lec0Lvu0k9ZPKJSjPugikirw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "ryanspletzer-github-io",
+  "version": "1.0.0",
+  "description": "Visual regression tests for Jekyll blog",
+  "private": true,
+  "scripts": {
+    "test:visual": "playwright test",
+    "test:visual:update": "playwright test --update-snapshots",
+    "test:visual:ui": "playwright test --ui",
+    "test:visual:report": "playwright show-report"
+  },
+  "devDependencies": {
+    "@playwright/test": "^1.50.0",
+    "@types/node": "^22.0.0",
+    "typescript": "^5.7.0"
+  }
+}

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,83 @@
+import { defineConfig } from '@playwright/test';
+
+/**
+ * Playwright configuration for visual regression testing.
+ * Tests run against the local Jekyll development server.
+ */
+export default defineConfig({
+  testDir: './e2e',
+
+  // Run tests sequentially for consistent screenshots
+  fullyParallel: false,
+
+  // Fail the build on CI if you accidentally left test.only in the source code
+  forbidOnly: !!process.env.CI,
+
+  // Retry on CI only
+  retries: process.env.CI ? 2 : 0,
+
+  // Single worker for visual tests to ensure consistency
+  workers: 1,
+
+  // Reporter configuration
+  reporter: process.env.CI
+    ? [['html', { open: 'never' }], ['github']]
+    : [['html', { open: 'on-failure' }]],
+
+  // Shared settings for all projects
+  use: {
+    // Base URL for the Jekyll dev server
+    baseURL: 'http://localhost:4000',
+
+    // Collect trace when retrying the failed test
+    trace: 'on-first-retry',
+
+    // Screenshot settings
+    screenshot: 'only-on-failure',
+  },
+
+  // Configure snapshot settings
+  snapshotPathTemplate: '{testDir}/{testFileDir}/__snapshots__/{testFileName}/{arg}-{projectName}{ext}',
+  expect: {
+    toHaveScreenshot: {
+      // Allow 0.2% pixel difference for cross-platform font rendering differences
+      maxDiffPixelRatio: 0.002,
+      // Threshold for per-pixel color difference (0-1)
+      threshold: 0.2,
+    },
+  },
+
+  // Projects for different viewport sizes (all use Chromium for consistency)
+  projects: [
+    {
+      name: 'Desktop',
+      use: {
+        browserName: 'chromium',
+        viewport: { width: 1280, height: 720 },
+      },
+    },
+    {
+      name: 'Tablet',
+      use: {
+        browserName: 'chromium',
+        viewport: { width: 768, height: 1024 },
+      },
+    },
+    {
+      name: 'Mobile',
+      use: {
+        browserName: 'chromium',
+        viewport: { width: 375, height: 667 },
+        isMobile: true,
+      },
+    },
+  ],
+
+  // Run local Jekyll server before starting tests
+  webServer: {
+    command: 'bundle exec jekyll serve --no-watch',
+    url: 'http://localhost:4000',
+    reuseExistingServer: !process.env.CI,
+    timeout: 120 * 1000, // Jekyll can take a while to build
+  },
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true,
+    "declaration": false,
+    "noEmit": true
+  },
+  "include": ["e2e/**/*.ts", "playwright.config.ts"]
+}


### PR DESCRIPTION
  Set up visual regression tests to capture baseline screenshots before
  refactoring HTML/CSS. Tests cover 9 page types across 3 viewports
  (Desktop 1280px, Tablet 768px, Mobile 375px) for 27 total screenshots.

  New files:
  - package.json: Node.js project with @playwright/test
  - playwright.config.ts: Test configuration with auto-start Jekyll server
  - e2e/visual-regression.spec.ts: Tests for homepage, posts, archive, tags, about, linkfarm, and 404 pages
  - e2e/__snapshots__/: Baseline screenshots
  - tsconfig.json: TypeScript configuration

  CI integration:
  - Added visual-tests job that runs before build/deploy
  - Added pull_request trigger for early feedback on PRs
  - Uploads diff reports as artifacts on failure

  Usage:
    npm run test:visual        # Run tests
    npm run test:visual:update # Update baselines
    npm run test:visual:ui     # Interactive UI
    npm run test:visual:report # View diff report