### PR TITLE
Extract shared layout-container utility and consolidate component selectors

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -55,7 +55,7 @@
 
   <header>
     <nav class="site-nav" aria-label="Main">
-      <div class="site-nav-inner">
+      <div class="site-nav-inner layout-container">
         <a class="site-title" href="{{ site.baseurl}}/">{{ site.name }}</a>
         <ul class="site-nav-links">
           <li><a href="{{ site.baseurl}}/" {% if page.url == "/" %}aria-current="page"{% endif %}>home</a></li>

--- a/_layouts/listing.html
+++ b/_layouts/listing.html
@@ -1,6 +1,6 @@
 {% include header.html %}
 
-<div class="site-content">
+<div class="site-content layout-container">
   <main id="main-content">
     <section>
       <div class="panel">

--- a/_layouts/page.html
+++ b/_layouts/page.html
@@ -1,6 +1,6 @@
 {% include header.html %}
 
-<div class="site-content">
+<div class="site-content layout-container">
   <main id="main-content">
     <article>
       <div class="panel">

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -1,6 +1,6 @@
 {% include header.html %}
 
-<div class="site-content">
+<div class="site-content layout-container">
   <main id="main-content">
     <article>
       <div class="panel panel-padded">

--- a/_sass/components.scss
+++ b/_sass/components.scss
@@ -15,25 +15,22 @@
   margin-top: 0.625rem;
 }
 
-.panel .post-content p,
-.panel .post-content ul,
-.panel .post-content ol {
-  font-family: var(--font-body);
-}
+// Post content area — typography and link behavior for rendered Markdown.
+.post-content {
+  p, ul, ol {
+    font-family: var(--font-body);
+  }
 
-// Underline links in content for WCAG 2.0 link-in-text-block compliance
-.post-content a {
-  text-decoration: underline;
-}
+  // Underline links for WCAG 2.0 link-in-text-block compliance
+  a {
+    text-decoration: underline;
+  }
 
-// Footnote links are visually distinct without underlines
-.post-content sup a.footnote,
-.post-content a.reversefootnote {
-  text-decoration: none;
-}
-
-.panel .post-meta ul {
-  font-family: var(--font-sans);
+  // Footnote links are visually distinct without underlines
+  sup a.footnote,
+  a.reversefootnote {
+    text-decoration: none;
+  }
 }
 
 .panel-padded {
@@ -95,6 +92,7 @@ h2.post-title:first-of-type {
     padding-left: 0;
     list-style: none;
     margin: 0;
+    font-family: var(--font-sans);
   }
 
   .post-time {

--- a/_sass/layout.scss
+++ b/_sass/layout.scss
@@ -1,3 +1,23 @@
+// Shared responsive container — defines the max-width cascade
+// used by .site-content and .site-nav-inner.
+// Applied as a utility class in HTML for visibility in DOM/devtools.
+.layout-container {
+  max-width: var(--layout-max-width);
+  margin-inline: auto;
+
+  @media (max-width: 74.9375em) {
+    max-width: 60.625rem;
+  }
+
+  @media (max-width: 61.9375em) {
+    max-width: 46.875rem;
+  }
+
+  @media (max-width: 47.9375em) {
+    max-width: none;
+  }
+}
+
 // Sticky footer via flexbox on body
 body {
   display: flex;
@@ -9,8 +29,6 @@ body {
 // lays out main + aside in a 9/3 grid with child-level padding.
 .site-content {
   flex: 1;
-  max-width: var(--layout-max-width);
-  margin-inline: auto;
   display: grid;
   grid-template-columns: 9fr 3fr;
 
@@ -24,12 +42,7 @@ body {
     min-width: 0;
   }
 
-  @media (max-width: 74.9375em) {
-    max-width: 60.625rem;
-  }
-
   @media (max-width: 61.9375em) {
-    max-width: 46.875rem;
     grid-template-columns: 1fr;
     padding: 0 0.9375rem;
 
@@ -37,10 +50,6 @@ body {
     > aside {
       padding: 0;
     }
-  }
-
-  @media (max-width: 47.9375em) {
-    max-width: none;
   }
 }
 
@@ -53,24 +62,10 @@ body {
   border-bottom: 1px solid #080808;
 
   .site-nav-inner {
-    max-width: var(--layout-max-width);
-    margin: 0 auto;
     padding: 0 0.9375rem;
     display: flex;
     align-items: center;
     justify-content: space-between;
-
-    @media (max-width: 74.9375em) {
-      max-width: 60.625rem;
-    }
-
-    @media (max-width: 61.9375em) {
-      max-width: 46.875rem;
-    }
-
-    @media (max-width: 47.9375em) {
-      max-width: none;
-    }
   }
 
   .site-title {


### PR DESCRIPTION
## Summary

- Extract a `.layout-container` utility class that defines the shared responsive max-width cascade, replacing duplicated breakpoint media queries in `.site-content` and `.site-nav-inner`
- Consolidate `.post-content` rules into a single nested block and drop unnecessary `.panel` parent selector
- Fold `.post-meta ul` font-family into the existing rule block, removing the standalone `.panel .post-meta ul` rule

## Test plan

- [x] `bundle exec jekyll build` — SCSS compiles without errors
- [x] `npm run test:visual` — 27/27 visual regression tests pass with zero pixel differences across Desktop, Tablet, and Mobile viewports
- [x] Compiled CSS size unchanged (~11KB)

🤖 Generated with [Claude Code](https://claude.com/claude-code)