### PR TITLE
Remove unused jekyll-gist plugin

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -180,7 +180,7 @@ regenerates Linux baseline screenshots and commits them.
 
 ### Ruby (Gemfile)
 
-jekyll, jekyll-gist, jekyll-redirect-from, kramdown-parser-gfm, jekyll-watch,
+jekyll, jekyll-redirect-from, kramdown-parser-gfm, jekyll-watch,
 webrick, colorator, concurrent-ruby
 
 ### Node.js (package.json)

--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,5 @@
 source "https://rubygems.org"
 gem 'jekyll'
-gem 'jekyll-gist'
 gem "kramdown-parser-gfm"
 gem 'jekyll-watch'
 gem 'webrick'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -12,12 +12,6 @@ GEM
       eventmachine (>= 0.12.9)
       http_parser.rb (~> 0)
     eventmachine (1.2.7)
-    faraday (2.14.1)
-      faraday-net_http (>= 2.0, < 3.5)
-      json
-      logger
-    faraday-net_http (3.4.2)
-      net-http (~> 0.5)
     ffi (1.17.2-arm64-darwin)
     ffi (1.17.2-x86_64-darwin)
     ffi (1.17.2-x86_64-linux-gnu)
@@ -53,8 +47,6 @@ GEM
       safe_yaml (~> 1.0)
       terminal-table (>= 1.8, < 4.0)
       webrick (~> 1.7)
-    jekyll-gist (1.5.0)
-      octokit (~> 4.2)
     jekyll-redirect-from (0.16.0)
       jekyll (>= 3.3, < 5.0)
     jekyll-sass-converter (3.1.0)
@@ -70,13 +62,7 @@ GEM
     listen (3.9.0)
       rb-fsevent (~> 0.10, >= 0.10.3)
       rb-inotify (~> 0.9, >= 0.9.10)
-    logger (1.7.0)
     mercenary (0.4.0)
-    net-http (0.9.1)
-      uri (>= 0.11.1)
-    octokit (4.25.1)
-      faraday (>= 1, < 3)
-      sawyer (~> 0.9)
     pathutil (0.16.2)
       forwardable-extended (~> 2.6)
     public_suffix (6.0.2)
@@ -93,13 +79,9 @@ GEM
       google-protobuf (~> 4.31)
     sass-embedded (1.93.3-x86_64-linux-gnu)
       google-protobuf (~> 4.31)
-    sawyer (0.9.3)
-      addressable (>= 2.3.5)
-      faraday (>= 0.17.3, < 3)
     terminal-table (3.0.2)
       unicode-display_width (>= 1.1.1, < 3)
     unicode-display_width (2.6.0)
-    uri (1.1.1)
     webrick (1.9.1)
 
 PLATFORMS
@@ -114,7 +96,6 @@ DEPENDENCIES
   colorator
   concurrent-ruby
   jekyll
-  jekyll-gist
   jekyll-redirect-from
   jekyll-watch
   kramdown-parser-gfm

--- a/_config.yml
+++ b/_config.yml
@@ -30,7 +30,6 @@ google_analytics_key: G-92E8FVFHFW
 permalink: /:year/:month/:title/
 
 plugins:
-  - jekyll-gist
   - jekyll-redirect-from
 
 # Enable for using pages, more details are here: http://jekyllrb.com/docs/pagination/


### PR DESCRIPTION
## Summary

- Remove `jekyll-gist` from `_config.yml`, `Gemfile`, and `Gemfile.lock`
- No posts or drafts use the `{% gist %}` Liquid tag
- Eliminates the `To use retry middleware with Faraday v2.0+, install faraday-retry gem` warning
- Drops 7 transitive dependencies: octokit, faraday, faraday-net_http, sawyer, logger, net-http, uri

## Test plan

- [ ] `bundle exec jekyll serve` runs without the Faraday warning
- [ ] Site builds and renders correctly
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)