### PR TITLE
Reduce dark mode background pattern opacity

### DIFF
--- a/_sass/typography.scss
+++ b/_sass/typography.scss
@@ -15,7 +15,8 @@ body {
   font-size: var(--size-body);
   line-height: var(--line-height-body);
   color: var(--color-text);
-  background: var(--color-bg) var(--bg-image);
+  background-color: var(--color-bg);
+  background-image: linear-gradient(var(--bg-overlay), var(--bg-overlay)), var(--bg-image);
   background-attachment: fixed;
   margin: 0;
 }

--- a/_sass/variables.scss
+++ b/_sass/variables.scss
@@ -33,6 +33,7 @@
   --color-filename-text: lightgrey;
   --color-skip-link-text: #000;
   --bg-image: url(/assets/images/commits-alpha-dark.png);
+  --bg-overlay: rgba(48, 48, 48, 0.7);
 
   // Syntax highlighting — VS Code Dark Modern defaults
   --syn-default: #D4D4D4;
@@ -109,6 +110,7 @@
   --color-filename-text: #57606A;
   --color-skip-link-text: #FFFFFF;
   --bg-image: url(/assets/images/commits-alpha-light.png);
+  --bg-overlay: transparent;
 
   // Syntax highlighting — VS Code Light Modern
   --syn-default: #383A42;

--- a/_sass/variables.scss
+++ b/_sass/variables.scss
@@ -33,7 +33,7 @@
   --color-filename-text: lightgrey;
   --color-skip-link-text: #000;
   --bg-image: url(/assets/images/commits-alpha-dark.png);
-  --bg-overlay: rgba(48, 48, 48, 0.7);
+  --bg-overlay: rgba(48, 48, 48, 0.6);
 
   // Syntax highlighting — VS Code Dark Modern defaults
   --syn-default: #D4D4D4;


### PR DESCRIPTION
## Summary

- Add a CSS overlay layer (`--bg-overlay`) between the commits grid background image and content to reduce visual busyness in dark mode
- Dark mode uses `rgba(48, 48, 48, 0.6)` overlay; light mode is unaffected (`transparent`)
- No baseline screenshot changes — the pattern is subtle enough that pixel differences fall below the snapshot threshold

## Test plan

- [ ] Verify dark mode background pattern is visibly softer
- [ ] Verify light mode background is unchanged
- [ ] Verify high-contrast mode still disables the background image entirely
- [ ] Visual regression tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)