### PR TITLE
Add RTL support via CSS logical properties

### DIFF
--- a/_sass/code.scss
+++ b/_sass/code.scss
@@ -6,6 +6,7 @@ pre {
 
 // Embedded code snippets
 .highlight {
+  direction: ltr;
   color: var(--color-text);
   background-color: var(--color-code-bg);
   border-radius: var(--radius-block);

--- a/_sass/components.scss
+++ b/_sass/components.scss
@@ -63,7 +63,7 @@
 // Post title on homepage listing
 h2.post-title {
   padding-top: 0.625rem;
-  text-align: left;
+  text-align: start;
 }
 
 h2.post-title:first-of-type {
@@ -95,7 +95,7 @@ h2.post-title:first-of-type {
     display: flex;
     flex-wrap: wrap;
     gap: 0.375rem;
-    padding-left: 0;
+    padding-inline-start: 0;
     list-style: none;
     margin: 0;
     font-family: var(--font-sans);
@@ -134,7 +134,7 @@ h2.post-title:first-of-type {
 .skip-link {
   position: absolute;
   top: -100%;
-  left: 0;
+  inset-inline-start: 0;
   padding: 0.5rem 1rem;
   background: var(--color-accent);
   color: var(--color-skip-link-text);
@@ -150,8 +150,7 @@ h2.post-title:first-of-type {
 // Table of contents
 .toc {
   background-color: var(--color-toc-bg);
-  margin-left: -1.75rem;
-  margin-right: -1.75rem;
+  margin-inline: -1.75rem;
 }
 
 // Theme toggle — pill-shaped light/dark switch
@@ -192,7 +191,7 @@ h2.post-title:first-of-type {
 .toggle-thumb {
   position: absolute;
   top: 50%;
-  left: 0.125rem;
+  inset-inline-start: 0.125rem;
   width: 1.125rem;
   height: 1.125rem;
   background: var(--color-accent);
@@ -203,18 +202,18 @@ h2.post-title:first-of-type {
 // Thumb position: OS prefers light (unless user chose dark)
 @media (prefers-color-scheme: light) {
   :root:not([data-theme="dark"]) .toggle-thumb {
-    left: calc(100% - 1.25rem);
+    inset-inline-start: calc(100% - 1.25rem);
   }
 }
 
 // Thumb position: user explicitly chose light
 :root[data-theme="light"] .toggle-thumb {
-  left: calc(100% - 1.25rem);
+  inset-inline-start: calc(100% - 1.25rem);
 }
 
 // Thumb position: user explicitly chose dark
 :root[data-theme="dark"] .toggle-thumb {
-  left: 0.125rem;
+  inset-inline-start: 0.125rem;
 }
 
 .toggle-icon {

--- a/_sass/layout.scss
+++ b/_sass/layout.scss
@@ -71,7 +71,7 @@ body {
   }
 
   .site-title {
-    margin-right: auto;
+    margin-inline-end: auto;
     font-size: 1.875rem;
     color: var(--color-link-hover);
     text-decoration: none;
@@ -195,8 +195,7 @@ body {
   .site-nav .site-nav-links:popover-open {
     inset: unset;
     top: 3.75rem;
-    left: 0;
-    right: 0;
+    inset-inline: 0;
     margin: 0;
     display: flex;
     flex-direction: column;
@@ -265,7 +264,7 @@ body {
   }
 
   .toggle-thumb {
-    transition: left var(--transition-fast);
+    transition: inset-inline-start var(--transition-fast);
   }
 }
 

--- a/_sass/typography.scss
+++ b/_sass/typography.scss
@@ -51,8 +51,7 @@ img {
 
 img + em {
   display: block;
-  margin-left: auto;
-  margin-right: auto;
+  margin-inline: auto;
   text-align: center;
 }
 
@@ -61,7 +60,7 @@ blockquote {
   font-size: 1em;
   margin: 0 0 1.25rem;
   padding: 0.625rem 1.25rem;
-  border-left: 5px solid var(--color-border);
+  border-inline-start: 5px solid var(--color-border);
 }
 
 a {
@@ -91,7 +90,7 @@ dl {
 }
 
 dd {
-  margin-left: 0;
+  margin-inline-start: 0;
   line-height: var(--line-height-body);
 }
 
@@ -121,7 +120,7 @@ table th,
 table td {
   border: 1px solid var(--color-table-border);
   padding: 0.5rem 0.75rem;
-  text-align: left;
+  text-align: start;
 }
 
 table th {

--- a/_sass/utilities.scss
+++ b/_sass/utilities.scss
@@ -49,21 +49,21 @@ kbd {
 .note {
   position: relative;
   border: 0;
-  border-left: 4px solid var(--color-note);
-  padding-left: 1.875rem;
+  border-inline-start: 4px solid var(--color-note);
+  padding-inline-start: 1.875rem;
 }
 
 .note:before {
   content: "\2139";
   font-size: 1.5em;
-  left: 0.375rem;
+  inset-inline-start: 0.375rem;
   position: absolute;
   top: 0;
   color: var(--color-note);
 }
 
 .warning {
-  border-left-color: var(--color-warning);
+  border-inline-start-color: var(--color-warning);
 }
 
 .warning:before {


### PR DESCRIPTION
## Summary

- Convert physical directional CSS properties (`left`, `margin-left`, `border-left`, `text-align: left`, etc.) to CSS logical equivalents (`inset-inline-start`, `margin-inline-start`, `border-inline-start`, `text-align: start`, etc.) across all SCSS files
- Add `direction: ltr` to `.highlight` so code blocks remain left-to-right in RTL contexts
- Enables the layout to flip correctly when a browser translator (e.g., Chrome Translate to Arabic) sets `dir="rtl"` on `<html>`

## Test plan

- [x] `bundle exec jekyll build` compiles without errors
- [x] Visual regression tests pass (`npm run test:visual`)
- [x] Open DevTools, set `<html dir="rtl">`, verify layout flips (blockquotes, notes, sidebar, toggle thumb, nav, grid)
- [x] Verify code blocks stay LTR under `dir="rtl"`

🤖 Generated with [Claude Code](https://claude.com/claude-code)