### PR TITLE
Accessibility improvements: ARIA cleanup and landmarks

### DIFF
--- a/_includes/sidebar.html
+++ b/_includes/sidebar.html
@@ -14,7 +14,7 @@
   <nav aria-label="External links">
     <ul>
       {% for link in site.links%}
-      <li><a href="{{ link.url }}" target="_blank" rel="noopener noreferrer">{{ link.text }}</a></li>
+      <li><a href="{{ link.url }}" target="_blank" rel="noopener noreferrer">{{ link.text }} <span class="sr-only">(opens in new tab)</span></a></li>
       {% endfor %}
     </ul>
   </nav>

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -20,7 +20,6 @@
           </div>
         </header>
         <div class="post-content">
-          <div id="toc" class="toc"></div>
           {{ content }}
         </div>
       </div>

--- a/_sass/components.scss
+++ b/_sass/components.scss
@@ -103,7 +103,7 @@ h2.post-title:first-of-type {
 
   li a {
     display: block;
-    background-color: var(--color-toc-bg);
+    background-color: var(--color-surface-subtle);
     border-radius: var(--radius-inline);
     padding: 0.125em 0.5em;
     font-size: 0.875em;
@@ -147,12 +147,6 @@ h2.post-title:first-of-type {
   }
 }
 
-// Table of contents
-.toc {
-  background-color: var(--color-toc-bg);
-  margin-inline: -1.75rem;
-}
-
 // Theme toggle — pill-shaped light/dark switch
 // Hidden by default; JS adds .js-ready to reveal it
 .theme-toggle {
@@ -182,7 +176,7 @@ h2.post-title:first-of-type {
   position: relative;
   width: 3rem;
   height: 1.5rem;
-  background: var(--color-toc-bg);
+  background: var(--color-surface-subtle);
   border: 1px solid var(--color-border);
   border-radius: 0.75rem;
   padding: 0 0.25rem;

--- a/_sass/layout.scss
+++ b/_sass/layout.scss
@@ -252,7 +252,6 @@ body {
   .site-footer,
   .panel,
   .sidebar-panel,
-  .toc,
   .highlight,
   pre,
   li > code,

--- a/_sass/variables.scss
+++ b/_sass/variables.scss
@@ -22,7 +22,7 @@
   --color-table-border: #7e7e7e;
 
   --color-nav-border: #080808;
-  --color-toc-bg: #2c2c2c;
+  --color-surface-subtle: #2c2c2c;
   --color-scrollbar-bg: #1E1E1E;
   --color-scrollbar-thumb: #424242;
   --color-code-shadow: 0 1px 3px rgba(0, 0, 0, 0.4);
@@ -98,7 +98,7 @@
   --color-table-border: #D0D7DE;
 
   --color-nav-border: #D0D7DE;
-  --color-toc-bg: #F6F8FA;
+  --color-surface-subtle: #F6F8FA;
   --color-scrollbar-bg: #F6F8FA;
   --color-scrollbar-thumb: #C0C0C0;
   --color-code-shadow: 0 1px 3px rgba(0, 0, 0, 0.08);

--- a/index.html
+++ b/index.html
@@ -15,13 +15,11 @@ layout: listing
       <div class="post-time">
         <time datetime='{{ post.date | date: "%Y-%m-%d" }}'>{{ post.date | date: "%B %d, %Y" }}</time>
       </div>
-      <nav aria-label="Post tags">
-        <ul>
-          {% for tag in post.tags %}
-          <li><a href="{{site.baseurl }}/tag/{{ tag }}">{{ tag }}</a></li>
-          {% endfor %}
-        </ul>
-      </nav>
+      <ul aria-label="Post tags">
+        {% for tag in post.tags %}
+        <li><a href="{{site.baseurl }}/tag/{{ tag }}">{{ tag }}</a></li>
+        {% endfor %}
+      </ul>
     </div>
   </header>
 

--- a/index.html
+++ b/index.html
@@ -15,11 +15,13 @@ layout: listing
       <div class="post-time">
         <time datetime='{{ post.date | date: "%Y-%m-%d" }}'>{{ post.date | date: "%B %d, %Y" }}</time>
       </div>
-      <ul>
-        {% for tag in post.tags %}
-        <li><a href="{{site.baseurl }}/tag/{{ tag }}">{{ tag }}</a></li>
-        {% endfor %}
-      </ul>
+      <nav aria-label="Post tags">
+        <ul>
+          {% for tag in post.tags %}
+          <li><a href="{{site.baseurl }}/tag/{{ tag }}">{{ tag }}</a></li>
+          {% endfor %}
+        </ul>
+      </nav>
     </div>
   </header>
 


### PR DESCRIPTION
## Summary

- Remove unused TOC container (`<div id="toc">`) from post layout and its `.toc` CSS rule; rename `--color-toc-bg` to `--color-surface-subtle` since the variable is used for tag pills and the theme toggle, not a table of contents
- Wrap homepage tag lists in `<nav aria-label="Post tags">` to match the pattern used in the single-post layout
- Add visually hidden "(opens in new tab)" hint to sidebar external links for screen reader users

## Test plan

- [x] Verify tag pills and theme toggle track render unchanged (variable rename only)
- [x] Run visual regression tests (`npm run test:visual`) to confirm no visual diff
- [x] Screen reader test: homepage tag lists announced as "Post tags" navigation
- [x] Screen reader test: sidebar external links announce "(opens in new tab)"

🤖 Generated with [Claude Code](https://claude.com/claude-code)