### PR TITLE
Remove redundant :focus-visible rules

### DIFF
--- a/_sass/components.scss
+++ b/_sass/components.scss
@@ -163,8 +163,6 @@ h2.post-title:first-of-type {
   }
 
   &:focus-visible {
-    outline: 2px solid var(--color-accent);
-    outline-offset: 2px;
     border-radius: 1rem;
   }
 }

--- a/_sass/layout.scss
+++ b/_sass/layout.scss
@@ -84,11 +84,6 @@ body {
       color: var(--color-accent);
       text-decoration: none;
     }
-
-    &:focus-visible {
-      outline: 2px solid var(--color-accent);
-      outline-offset: 2px;
-    }
   }
 
   .site-nav-links {
@@ -120,11 +115,6 @@ body {
       &:focus {
         color: var(--color-link-hover);
         text-decoration: none;
-      }
-
-      &:focus-visible {
-        outline: 2px solid var(--color-accent);
-        outline-offset: 2px;
       }
     }
 
@@ -238,11 +228,6 @@ body {
     transform: rotate(-45deg);
   }
 
-  // Focus indicator — direct on button
-  .nav-toggle-btn:focus-visible {
-    outline: 2px solid var(--color-accent);
-    outline-offset: 2px;
-  }
 }
 
 // Theme switch animation (disabled when reduced motion is preferred)


### PR DESCRIPTION
## Summary

- Remove 3 duplicate `:focus-visible` blocks from `layout.scss` (`.site-title a`, `.site-nav-links li a`, `.nav-toggle-btn`) that repeat the global catch-all in `typography.scss`
- Slim `.theme-toggle:focus-visible` in `components.scss` to only its unique `border-radius: 1rem`, inheriting `outline` from the global rule
- Net removal of 17 lines with no visual change (56/56 Playwright tests pass)

## Test plan

- [x] `bundle exec jekyll build` succeeds
- [x] Compiled CSS contains only 2 `:focus-visible` rules (global + theme toggle border-radius)
- [x] All 56 Playwright visual regression tests pass across 6 projects

🤖 Generated with [Claude Code](https://claude.com/claude-code)