### PR TITLE
Add VS Code recommended extensions

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,8 @@
+{
+  "enabledPlugins": {
+    "frontend-design@claude-plugins-official": true,
+    "playwright@claude-plugins-official": true,
+    "accesslint@accesslint": true,
+    "typescript-lsp@claude-plugins-official": true
+  }
+}

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,13 @@
+{
+  "recommendations": [
+    "shopify.ruby-lsp",
+    "sissel.shopify-liquid",
+    "redhat.vscode-yaml",
+    "davidanson.vscode-markdownlint",
+    "ms-playwright.playwright",
+    "ms-vscode.powershell",
+    "dbaeumer.vscode-eslint",
+    "oderwat.indent-rainbow",
+    "esbenp.prettier-vscode"
+  ]
+}


### PR DESCRIPTION
## Summary

- Adds `.vscode/extensions.json` with recommended extensions for the project (Ruby LSP, Liquid, YAML, markdownlint, Playwright, PowerShell, ESLint, Indent Rainbow, Prettier)

## Test plan

- [ ] Verify VS Code shows extension recommendations when opening the project

🤖 Generated with [Claude Code](https://claude.com/claude-code)