### PR TITLE
Pin Sonnet model and add compact instructions for cost optimization

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,4 +1,5 @@
 {
+  "model": "sonnet",
   "enabledPlugins": {
     "frontend-design@claude-plugins-official": true,
     "playwright@claude-plugins-official": true,

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,6 +8,10 @@ Jekyll-based personal blog at **<www.spletzer.com>**. Hosted on GitHub Pages
 with Cloudflare in front. Custom domain via `CNAME` file. Licensed under
 CC BY 4.0.
 
+## Compact instructions
+
+When compacting, focus on test output and code changes.
+
 ## Build and Development Commands
 
 ### Local Development


### PR DESCRIPTION
## Summary

- Explicitly pins `"model": "sonnet"` in `.claude/settings.json` to match the per-project tiering rubric and remain resilient to global default changes
- Adds compact instructions to `CLAUDE.md` so context compression focuses on test output and code changes, which matters for a repo with 54 Playwright visual regression tests

## Test plan

- [ ] Verify `.claude/settings.json` has `"model": "sonnet"` at the top level
- [ ] Verify `CLAUDE.md` has the `## Compact instructions` section before `## Build and Development Commands`

🤖 Generated with [Claude Code](https://claude.com/claude-code)