### PR TITLE
Fix Playwright cache key and Actions injection risk

### DIFF
--- a/.github/workflows/jekyll.yml
+++ b/.github/workflows/jekyll.yml
@@ -84,12 +84,16 @@ jobs:
       - name: Install npm dependencies
         run: npm ci
 
+      - name: Get Playwright version
+        id: playwright-version
+        run: echo "version=$(npx playwright --version | awk '{print $2}')" >> $GITHUB_OUTPUT
+
       - name: Cache Playwright browsers
         uses: actions/cache@v5
         id: playwright-cache
         with:
           path: ~/.cache/ms-playwright
-          key: playwright-${{ runner.os }}-${{ hashFiles('package-lock.json') }}
+          key: playwright-${{ runner.os }}-${{ steps.playwright-version.outputs.version }}
 
       - name: Install Playwright Chromium
         if: steps.playwright-cache.outputs.cache-hit != 'true'

--- a/.github/workflows/update-visual-baselines.yml
+++ b/.github/workflows/update-visual-baselines.yml
@@ -44,12 +44,16 @@ jobs:
       - name: Install npm dependencies
         run: npm ci
 
+      - name: Get Playwright version
+        id: playwright-version
+        run: echo "version=$(npx playwright --version | awk '{print $2}')" >> $GITHUB_OUTPUT
+
       - name: Cache Playwright browsers
         uses: actions/cache@v5
         id: playwright-cache
         with:
           path: ~/.cache/ms-playwright
-          key: playwright-${{ runner.os }}-${{ hashFiles('package-lock.json') }}
+          key: playwright-${{ runner.os }}-${{ steps.playwright-version.outputs.version }}
 
       - name: Install Playwright Chromium
         if: steps.playwright-cache.outputs.cache-hit != 'true'
@@ -67,11 +71,13 @@ jobs:
           git config user.email "github-actions[bot]@users.noreply.github.com"
 
       - name: Commit and push baselines
+        env:
+          COMMIT_MESSAGE: ${{ github.event.inputs.commit_message }}
         run: |
           git add e2e/__snapshots__/
           if git diff --staged --quiet; then
             echo "No changes to baselines"
           else
-            git commit -m "${{ github.event.inputs.commit_message }}"
+            git commit -m "$COMMIT_MESSAGE"
             git push
           fi


### PR DESCRIPTION
## Summary

- Switches Playwright browser cache key from `hashFiles('package-lock.json')` to the installed Playwright version string (e.g. `playwright-Linux-1.60.0`), so the cache only invalidates when Playwright itself is upgraded — not on unrelated dep changes
- Fixes a pre-existing command injection risk in `update-visual-baselines.yml` where `${{ github.event.inputs.commit_message }}` was interpolated directly into a `run:` command; now passed via `env:` variable per GitHub's security guidance

## Test plan

- [ ] Visual regression tests pass in CI (cache miss on first run, then hit on subsequent runs with same Playwright version)